### PR TITLE
Init process and service IPC groundwork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
  "bundlemgr",
  "capnp",
  "nexus-idl-runtime",
+ "nexus-ipc",
 ]
 
 [[package]]
@@ -661,6 +662,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nexus-init"
+version = "0.1.0"
+dependencies = [
+ "bundlemgrd",
+ "samgrd",
+ "serde",
+ "tempfile",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "nexus-ipc"
+version = "0.1.0"
+dependencies = [
+ "nexus-abi",
+ "parking_lot",
+ "thiserror",
+]
+
+[[package]]
 name = "nexus-sched"
 version = "0.1.0"
 
@@ -1010,6 +1032,7 @@ version = "0.1.0"
 dependencies = [
  "capnp",
  "nexus-idl-runtime",
+ "nexus-ipc",
  "samgr",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "source/kernel/neuron",
     "source/libs/*",
     "source/services/*",
+    "source/init/*",
     "userspace/*",
     "source/apps/launcher",
     "source/drivers/net/virtio",

--- a/recipes/services/bundlemgrd.toml
+++ b/recipes/services/bundlemgrd.toml
@@ -1,0 +1,2 @@
+name = "bundlemgrd"
+entry = "bundlemgrd"

--- a/recipes/services/samgrd.toml
+++ b/recipes/services/samgrd.toml
@@ -1,0 +1,2 @@
+name = "samgrd"
+entry = "samgrd"

--- a/scripts/detect-cfg.sh
+++ b/scripts/detect-cfg.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Copyright 2024 Open Nexus OS Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+CONFIG_FILE="${REPO_ROOT}/.cargo/config.toml"
+
+mapfile -t CANDIDATES < <(python3 <<'PY'
+import os
+import pathlib
+import re
+import shlex
+import subprocess
+
+root = pathlib.Path(__file__).resolve().parents[1]
+config_path = root / ".cargo" / "config.toml"
+pattern = re.compile(r"--cfg(?:=|\s+)(?:\"([^\"]+)\"|'([^']+)'|([^\s,]+))")
+
+candidates: list[str] = []
+
+def add_flag(flag: str) -> None:
+    flag = flag.strip()
+    if not flag:
+        return
+    flag = flag.replace('\\"', '"').replace("\\'", "'")
+    flag = flag.strip("'")
+    while flag.endswith('"') and flag.count('"') % 2 == 1:
+        flag = flag[:-1]
+    while flag.startswith('"') and flag.count('"') % 2 == 1:
+        flag = flag[1:]
+    if flag not in candidates:
+        candidates.append(flag)
+
+
+def parse_sequence(seq) -> None:
+    if isinstance(seq, str):
+        parse_text(seq)
+        return
+    if isinstance(seq, (list, tuple)):
+        for idx, item in enumerate(seq):
+            if isinstance(item, str):
+                if item == "--cfg" and idx + 1 < len(seq):
+                    add_flag(seq[idx + 1])
+                elif item.startswith("--cfg="):
+                    add_flag(item.split("=", 1)[1])
+                else:
+                    parse_text(item)
+            elif isinstance(item, (list, tuple)):
+                parse_sequence(item)
+            elif isinstance(item, dict):
+                parse_mapping(item)
+        return
+    if isinstance(seq, dict):
+        parse_mapping(seq)
+
+
+def parse_mapping(mapping: dict) -> None:
+    for value in mapping.values():
+        if isinstance(value, (list, tuple, dict, str)):
+            parse_sequence(value)
+
+
+def parse_text(text: str) -> None:
+    for match in pattern.finditer(text):
+        for group in match.groups():
+            if group:
+                add_flag(group)
+
+if config_path.exists():
+    import tomllib
+
+    data = tomllib.loads(config_path.read_text())
+    parse_sequence(data)
+
+env_flags = os.environ.get("RUSTFLAGS")
+if env_flags:
+    tokens = shlex.split(env_flags)
+    parse_sequence(tokens)
+
+try:
+    rg = subprocess.run(
+        [
+            "rg",
+            "--no-heading",
+            "--no-line-number",
+            "--color=never",
+            "-e",
+            r"--cfg(?:=|\s+)nexus_[^\s]+",
+            str(root),
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    if rg.stdout:
+        parse_text(rg.stdout)
+except FileNotFoundError:
+    pass
+
+for flag in candidates:
+    print(flag)
+PY
+)
+
+HOST_FLAG=""
+OS_FLAG=""
+
+for flag in "${CANDIDATES[@]}"; do
+    if [[ -z "${HOST_FLAG}" ]]; then
+        if [[ "${flag}" == *'"host"'* ]] || [[ "${flag}" == *'_host'* ]] || [[ "${flag}" == *=host ]]; then
+            HOST_FLAG="${flag}"
+            [[ -n "${OS_FLAG}" ]] && break
+            continue
+        fi
+    fi
+    if [[ -z "${OS_FLAG}" ]]; then
+        if [[ "${flag}" == *'"os"'* ]] || [[ "${flag}" == *'_os'* ]] || [[ "${flag}" == *=os ]]; then
+            OS_FLAG="${flag}"
+            [[ -n "${HOST_FLAG}" ]] && break
+            continue
+        fi
+    fi
+    if [[ -n "${HOST_FLAG}" && -n "${OS_FLAG}" ]]; then
+        break
+    fi
+done
+
+HOST_FLAG="${HOST_FLAG:-nexus_host}"
+OS_FLAG="${OS_FLAG:-nexus_os}"
+
+printf 'export NEXUS_CFG_HOST=%s\n' "$(printf '%q' "${HOST_FLAG}")"
+printf 'export NEXUS_CFG_OS=%s\n' "$(printf '%q' "${OS_FLAG}")"

--- a/source/init/nexus-init/Cargo.toml
+++ b/source/init/nexus-init/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nexus-init"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+thiserror = "1"
+samgrd = { path = "../../services/samgrd" }
+bundlemgrd = { path = "../../services/bundlemgrd" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/source/init/nexus-init/src/main.rs
+++ b/source/init/nexus-init/src/main.rs
@@ -1,0 +1,319 @@
+// Copyright 2024 Open Nexus OS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Minimal init process responsible for launching core services and emitting
+//! deterministic UART markers for the OS test harness.
+
+#![forbid(unsafe_code)]
+#![deny(clippy::all, missing_docs)]
+#![allow(unexpected_cfgs)]
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use serde::Deserialize;
+use thiserror::Error;
+
+const CORE_SERVICES: [&str; 2] = ["samgrd", "bundlemgrd"];
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("init: fatal error: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), InitError> {
+    println!("init: start");
+    let mut catalog = ServiceCatalog::load(Path::new("recipes/services"))?;
+    catalog.ensure_core_defaults();
+
+    let mut handles = Vec::new();
+    for name in CORE_SERVICES {
+        let config = catalog
+            .get(name)
+            .cloned()
+            .ok_or_else(|| InitError::MissingService(name.to_string()))?;
+        let handle = runtime::spawn_service(&config)?;
+        handle.wait_ready()?;
+        println!("init: {name} up");
+        handles.push(handle);
+    }
+
+    println!("init: ready");
+    runtime::idle(handles)
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct RawService {
+    name: Option<String>,
+    entry: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct ServiceConfig {
+    name: String,
+    entry: String,
+}
+
+impl ServiceConfig {
+    fn new<N: Into<String>, E: Into<String>>(name: N, entry: E) -> Self {
+        Self {
+            name: name.into(),
+            entry: entry.into(),
+        }
+    }
+}
+
+struct ServiceCatalog {
+    services: HashMap<String, ServiceConfig>,
+}
+
+impl ServiceCatalog {
+    fn load(path: &Path) -> Result<Self, InitError> {
+        let mut services = HashMap::new();
+        if path.is_dir() {
+            for entry in fs::read_dir(path).map_err(|source| InitError::Io {
+                path: path.to_path_buf(),
+                source,
+            })? {
+                let entry = entry.map_err(|source| InitError::Io {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+                let file_path = entry.path();
+                if file_path.extension().and_then(|ext| ext.to_str()) != Some("toml") {
+                    continue;
+                }
+                let raw = fs::read_to_string(&file_path).map_err(|source| InitError::Io {
+                    path: file_path.clone(),
+                    source,
+                })?;
+                let recipe: RawService =
+                    toml::from_str(&raw).map_err(|source| InitError::Parse {
+                        path: file_path.clone(),
+                        source,
+                    })?;
+                let name = recipe.name.ok_or_else(|| InitError::InvalidRecipe {
+                    path: file_path.clone(),
+                    reason: "missing name".into(),
+                })?;
+                let entry = recipe.entry.unwrap_or_else(|| name.clone());
+                let config = ServiceConfig::new(name.clone(), entry);
+                if services.insert(name.clone(), config).is_some() {
+                    return Err(InitError::DuplicateService(name));
+                }
+            }
+        }
+        Ok(Self { services })
+    }
+
+    fn ensure_core_defaults(&mut self) {
+        for name in CORE_SERVICES {
+            self.services
+                .entry(name.to_string())
+                .or_insert_with(|| ServiceConfig::new(name, name));
+        }
+    }
+
+    fn get(&self, name: &str) -> Option<&ServiceConfig> {
+        self.services.get(name)
+    }
+}
+
+/// Error produced by the init runtime.
+#[derive(Debug, Error)]
+pub enum InitError {
+    /// Failed to access a file or directory inside the recipe tree.
+    #[error("failed to access {path}: {source}")]
+    Io {
+        /// Location associated with the error.
+        path: PathBuf,
+        /// Underlying operating system error.
+        source: std::io::Error,
+    },
+    /// TOML parsing failed for a service recipe.
+    #[error("failed to parse service recipe {path}: {source}")]
+    Parse {
+        /// Location of the malformed recipe file.
+        path: PathBuf,
+        /// Error returned by the TOML deserializer.
+        source: toml::de::Error,
+    },
+    /// Recipe was missing mandatory metadata.
+    #[error("invalid service recipe {path}: {reason}")]
+    InvalidRecipe {
+        /// Location of the malformed recipe file.
+        path: PathBuf,
+        /// Human readable description of the issue.
+        reason: String,
+    },
+    /// Encountered the same service name multiple times while loading recipes.
+    #[error("duplicate service definition for {0}")]
+    DuplicateService(String),
+    /// Spawning the service thread failed.
+    #[error("service {name} spawn failed: {source}")]
+    Spawn {
+        /// Logical service name.
+        name: String,
+        /// Reason reported by the thread builder.
+        source: std::io::Error,
+    },
+    /// Configuration referenced a service that could not be located.
+    #[error("service {0} missing from catalog")]
+    MissingService(String),
+    /// Service failed to report readiness and terminated early.
+    #[error("service {0} failed during startup")]
+    ServiceFailed(String),
+    /// Service reported a fatal runtime error.
+    #[error("service {service} error: {detail}")]
+    ServiceError {
+        /// Name of the failing service.
+        service: String,
+        /// Human readable details from the daemon.
+        detail: String,
+    },
+    /// Recipe referenced an entry point that is not supported yet.
+    #[error("service {service} references unsupported entry {entry}")]
+    UnsupportedEntry {
+        /// Service that declared the entry.
+        service: String,
+        /// Requested entry symbol.
+        entry: String,
+    },
+}
+
+mod runtime {
+    use super::{InitError, ServiceConfig};
+    use std::sync::mpsc::{self, Receiver, Sender};
+    use std::thread;
+
+    pub struct ServiceHandle {
+        name: String,
+        ready: Receiver<ServiceStatus>,
+        #[allow(dead_code)]
+        join: thread::JoinHandle<()>,
+    }
+
+    impl ServiceHandle {
+        pub fn wait_ready(&self) -> Result<(), InitError> {
+            match self.ready.recv() {
+                Ok(ServiceStatus::Ready) => Ok(()),
+                Ok(ServiceStatus::Failed(err)) => Err(err),
+                Err(_) => Err(InitError::ServiceFailed(self.name.clone())),
+            }
+        }
+    }
+
+    pub enum ServiceStatus {
+        Ready,
+        Failed(InitError),
+    }
+
+    type ReadySender = Sender<ServiceStatus>;
+
+    pub fn spawn_service(service: &ServiceConfig) -> Result<ServiceHandle, InitError> {
+        let service = service.clone();
+        let name = service.name.clone();
+        let (tx, rx) = mpsc::channel();
+        let join = thread::Builder::new()
+            .name(format!("svc-{}", &name))
+            .spawn(move || service_registry::launch(service, tx))
+            .map_err(|source| InitError::Spawn {
+                name: name.clone(),
+                source,
+            })?;
+        Ok(ServiceHandle {
+            name,
+            ready: rx,
+            join,
+        })
+    }
+
+    pub fn idle(handles: Vec<ServiceHandle>) -> ! {
+        let _handles = handles;
+        loop {
+            thread::park();
+        }
+    }
+
+    mod service_registry {
+        use super::{ReadySender, ServiceConfig, ServiceStatus};
+        use crate::InitError;
+
+        pub fn launch(service: ServiceConfig, ready: ReadySender) {
+            let ServiceConfig { name, entry } = service;
+            match entry.as_str() {
+                "samgrd" => {
+                    let ready_clone = ready.clone();
+                    let notifier = samgrd::ReadyNotifier::new(move || {
+                        let _ = ready_clone.send(ServiceStatus::Ready);
+                    });
+                    if let Err(err) = samgrd::service_main_loop(notifier) {
+                        let detail = err.to_string();
+                        let _ = ready.send(ServiceStatus::Failed(InitError::ServiceError {
+                            service: name,
+                            detail,
+                        }));
+                    }
+                }
+                "bundlemgrd" => {
+                    let ready_clone = ready.clone();
+                    let notifier = bundlemgrd::ReadyNotifier::new(move || {
+                        let _ = ready_clone.send(ServiceStatus::Ready);
+                    });
+                    let artifacts = bundlemgrd::ArtifactStore::new();
+                    if let Err(err) = bundlemgrd::service_main_loop(notifier, artifacts) {
+                        let detail = err.to_string();
+                        let _ = ready.send(ServiceStatus::Failed(InitError::ServiceError {
+                            service: name,
+                            detail,
+                        }));
+                    }
+                }
+                other => {
+                    let err = InitError::UnsupportedEntry {
+                        service: name,
+                        entry: other.to_string(),
+                    };
+                    let _ = ready.send(ServiceStatus::Failed(err));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+
+    #[test]
+    fn loads_default_when_directory_missing() {
+        let mut catalog = ServiceCatalog::load(Path::new("/non-existent/path")).unwrap();
+        catalog.ensure_core_defaults();
+        for name in CORE_SERVICES {
+            assert!(catalog.get(name).is_some(), "missing core service {name}");
+        }
+    }
+
+    #[test]
+    fn parses_service_recipe() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("samgrd.toml");
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(file, "name = \"samgrd\"").unwrap();
+        writeln!(file, "entry = \"samgrd-main\"").unwrap();
+        drop(file);
+        let mut catalog = ServiceCatalog::load(dir.path()).unwrap();
+        catalog.ensure_core_defaults();
+        let config = catalog.get("samgrd").unwrap();
+        assert_eq!(config.entry, "samgrd-main");
+    }
+}

--- a/source/libs/nexus-abi/src/lib.rs
+++ b/source/libs/nexus-abi/src/lib.rs
@@ -1,42 +1,102 @@
+// Copyright 2024 Open Nexus OS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_code)]
+#![deny(clippy::all, missing_docs)]
+
+//! Shared ABI definitions exposed to userland crates.
+
+use core::convert::TryInto;
+
+/// Result type returned by ABI helpers.
+pub type Result<T> = core::result::Result<T, IpcError>;
+
+/// Errors surfaced by IPC syscalls.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IpcError {
+    /// Referenced endpoint is not present in the router.
+    NoSuchEndpoint,
+    /// Target queue ran out of space.
+    QueueFull,
+    /// Queue did not contain a message when operating in non-blocking mode.
+    QueueEmpty,
+    /// Caller lacks permission to perform the requested operation.
+    PermissionDenied,
+    /// IPC is not supported for this configuration.
+    Unsupported,
+}
 
 /// IPC message header shared between kernel and userland.
+#[repr(C, align(4))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MsgHeader {
+    /// Source capability slot.
+    pub src: u32,
+    /// Destination endpoint identifier.
     pub dst: u32,
-    pub len: u16,
+    /// Message opcode.
+    pub ty: u16,
+    /// Transport flags.
     pub flags: u16,
+    /// Inline payload length.
+    pub len: u32,
 }
 
 impl MsgHeader {
-    pub const fn new(dst: u32, len: u16, flags: u16) -> Self {
-        Self { dst, len, flags }
+    /// Creates a new header with the provided fields.
+    pub const fn new(src: u32, dst: u32, ty: u16, flags: u16, len: u32) -> Self {
+        Self {
+            src,
+            dst,
+            ty,
+            flags,
+            len,
+        }
     }
 
-    pub fn serialize(&self) -> [u8; 8] {
-        let mut buf = [0_u8; 8];
-        buf[0..4].copy_from_slice(&self.dst.to_le_bytes());
-        buf[4..6].copy_from_slice(&self.len.to_le_bytes());
-        buf[6..8].copy_from_slice(&self.flags.to_le_bytes());
+    /// Serialises the header to a little-endian byte array.
+    pub fn to_le_bytes(&self) -> [u8; 16] {
+        let mut buf = [0_u8; 16];
+        buf[0..4].copy_from_slice(&self.src.to_le_bytes());
+        buf[4..8].copy_from_slice(&self.dst.to_le_bytes());
+        buf[8..10].copy_from_slice(&self.ty.to_le_bytes());
+        buf[10..12].copy_from_slice(&self.flags.to_le_bytes());
+        buf[12..16].copy_from_slice(&self.len.to_le_bytes());
         buf
     }
 
-    pub fn deserialize(bytes: [u8; 8]) -> Self {
-        let dst = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-        let len = u16::from_le_bytes([bytes[4], bytes[5]]);
-        let flags = u16::from_le_bytes([bytes[6], bytes[7]]);
-        Self { dst, len, flags }
+    /// Deserialises a little-endian byte array into a header.
+    pub fn from_le_bytes(bytes: [u8; 16]) -> Self {
+        let src = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let dst = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        let ty = u16::from_le_bytes(bytes[8..10].try_into().unwrap());
+        let flags = u16::from_le_bytes(bytes[10..12].try_into().unwrap());
+        let len = u32::from_le_bytes(bytes[12..16].try_into().unwrap());
+        Self {
+            src,
+            dst,
+            ty,
+            flags,
+            len,
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::MsgHeader;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn header_layout() {
+        assert_eq!(size_of::<MsgHeader>(), 16);
+        assert_eq!(align_of::<MsgHeader>(), 4);
+    }
 
     #[test]
     fn round_trip() {
-        let header = MsgHeader::new(42, 16, 3);
-        let bytes = header.serialize();
-        assert_eq!(header, MsgHeader::deserialize(bytes));
+        let header = MsgHeader::new(1, 2, 3, 4, 5);
+        assert_eq!(header, MsgHeader::from_le_bytes(header.to_le_bytes()));
     }
 }

--- a/source/services/bundlemgrd/Cargo.toml
+++ b/source/services/bundlemgrd/Cargo.toml
@@ -12,6 +12,7 @@ idl-capnp = ["nexus-idl-runtime/capnp", "dep:capnp"]
 bundlemgr = { path = "../../../userspace/bundlemgr" }
 nexus-idl-runtime = { path = "../../../userspace/nexus-idl-runtime" }
 capnp = { version = "0.19", optional = true }
+nexus-ipc = { path = "../../../userspace/nexus-ipc" }
 
 [[bin]]
 name = "bundlemgrd"

--- a/source/services/bundlemgrd/src/main.rs
+++ b/source/services/bundlemgrd/src/main.rs
@@ -2,8 +2,10 @@
 
 fn main() -> ! {
     bundlemgrd::touch_schemas();
-    println!("bundlemgrd: ready");
-    if let Err(err) = bundlemgrd::run_default() {
+    let artifacts = bundlemgrd::ArtifactStore::new();
+    if let Err(err) =
+        bundlemgrd::service_main_loop(bundlemgrd::ReadyNotifier::new(|| ()), artifacts)
+    {
         eprintln!("bundlemgrd: {err}");
     }
     loop {

--- a/source/services/samgrd/Cargo.toml
+++ b/source/services/samgrd/Cargo.toml
@@ -12,6 +12,7 @@ idl-capnp = ["nexus-idl-runtime/capnp", "dep:capnp"]
 nexus-idl-runtime = { path = "../../../userspace/nexus-idl-runtime" }
 samgr = { path = "../../../userspace/samgr" }
 capnp = { version = "0.19", optional = true }
+nexus-ipc = { path = "../../../userspace/nexus-ipc" }
 
 [[bin]]
 name = "samgrd"

--- a/source/services/samgrd/src/main.rs
+++ b/source/services/samgrd/src/main.rs
@@ -2,8 +2,7 @@
 
 fn main() -> ! {
     samgrd::touch_schemas();
-    println!("samgrd: ready");
-    if let Err(err) = samgrd::run_default() {
+    if let Err(err) = samgrd::service_main_loop(samgrd::ReadyNotifier::new(|| ())) {
         eprintln!("samgrd: {err}");
     }
     loop {

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -3,129 +3,24 @@
 
 #![forbid(unsafe_code)]
 
-use std::sync::mpsc::{self, Receiver, Sender};
+#[cfg(nexus_env = "host")]
+use nexus_ipc::{LoopbackClient, LoopbackServer, Wait};
 
-/// Client endpoint used by tests to send requests and receive responses.
-pub struct LoopbackClient {
-    request_tx: Sender<Vec<u8>>,
-    response_rx: Receiver<Vec<u8>>,
+/// Client helper that sends a request frame and waits for the reply.
+#[cfg(nexus_env = "host")]
+pub fn call(client: &LoopbackClient, frame: Vec<u8>) -> Vec<u8> {
+    client.send(&frame, Wait::Blocking).expect("send frame");
+    client.recv(Wait::Blocking).expect("recv frame")
 }
 
-impl LoopbackClient {
-    fn new(request_tx: Sender<Vec<u8>>, response_rx: Receiver<Vec<u8>>) -> Self {
-        Self {
-            request_tx,
-            response_rx,
-        }
-    }
-
-    /// Sends a frame to the server and waits for the response.
-    pub fn call(&self, frame: Vec<u8>) -> Vec<u8> {
-        self.request_tx.send(frame).expect("send frame");
-        self.response_rx.recv().expect("recv frame")
-    }
+/// Creates a loopback transport pair for the SAMGR daemon.
+#[cfg(nexus_env = "host")]
+pub fn samgr_loopback() -> (LoopbackClient, samgrd::IpcTransport<LoopbackServer>) {
+    samgrd::loopback_transport()
 }
 
-struct ServerEndpoint {
-    request_rx: Receiver<Vec<u8>>,
-    response_tx: Sender<Vec<u8>>,
-}
-
-impl ServerEndpoint {
-    fn new() -> (LoopbackClient, Self) {
-        let (request_tx, request_rx) = mpsc::channel();
-        let (response_tx, response_rx) = mpsc::channel();
-        let client = LoopbackClient::new(request_tx, response_rx);
-        let server = Self {
-            request_rx,
-            response_tx,
-        };
-        (client, server)
-    }
-
-    fn recv(&self) -> Result<Option<Vec<u8>>, LoopbackError> {
-        match self.request_rx.recv() {
-            Ok(frame) => Ok(Some(frame)),
-            Err(_) => Ok(None),
-        }
-    }
-
-    fn send(&self, frame: &[u8]) -> Result<(), LoopbackError> {
-        self.response_tx
-            .send(frame.to_vec())
-            .map_err(|_| LoopbackError)
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct LoopbackError;
-
-impl Into<samgrd::TransportError> for LoopbackError {
-    fn into(self) -> samgrd::TransportError {
-        samgrd::TransportError::Closed
-    }
-}
-
-impl Into<bundlemgrd::TransportError> for LoopbackError {
-    fn into(self) -> bundlemgrd::TransportError {
-        bundlemgrd::TransportError::Closed
-    }
-}
-
-/// Server transport implementing `samgrd::Transport` using in-process channels.
-pub struct SamgrServerTransport {
-    endpoint: ServerEndpoint,
-}
-
-impl SamgrServerTransport {
-    fn new(endpoint: ServerEndpoint) -> Self {
-        Self { endpoint }
-    }
-}
-
-impl samgrd::Transport for SamgrServerTransport {
-    type Error = LoopbackError;
-
-    fn recv(&mut self) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.endpoint.recv()
-    }
-
-    fn send(&mut self, frame: &[u8]) -> Result<(), Self::Error> {
-        self.endpoint.send(frame)
-    }
-}
-
-/// Server transport implementing `bundlemgrd::Transport` using in-process channels.
-pub struct BundleServerTransport {
-    endpoint: ServerEndpoint,
-}
-
-impl BundleServerTransport {
-    fn new(endpoint: ServerEndpoint) -> Self {
-        Self { endpoint }
-    }
-}
-
-impl bundlemgrd::Transport for BundleServerTransport {
-    type Error = LoopbackError;
-
-    fn recv(&mut self) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.endpoint.recv()
-    }
-
-    fn send(&mut self, frame: &[u8]) -> Result<(), Self::Error> {
-        self.endpoint.send(frame)
-    }
-}
-
-/// Creates a loopback pair for the SAMGR daemon.
-pub fn samgr_loopback() -> (LoopbackClient, SamgrServerTransport) {
-    let (client, endpoint) = ServerEndpoint::new();
-    (client, SamgrServerTransport::new(endpoint))
-}
-
-/// Creates a loopback pair for the bundle manager daemon.
-pub fn bundle_loopback() -> (LoopbackClient, BundleServerTransport) {
-    let (client, endpoint) = ServerEndpoint::new();
-    (client, BundleServerTransport::new(endpoint))
+/// Creates a loopback transport pair for the bundle manager daemon.
+#[cfg(nexus_env = "host")]
+pub fn bundle_loopback() -> (LoopbackClient, bundlemgrd::IpcTransport<LoopbackServer>) {
+    bundlemgrd::loopback_transport()
 }

--- a/userspace/nexus-ipc/Cargo.toml
+++ b/userspace/nexus-ipc/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "nexus-ipc"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+authors = ["Open Nexus OS Contributors"]
+
+[dependencies]
+nexus-abi = { path = "../../source/libs/nexus-abi" }
+parking_lot = "0.12"
+thiserror = "1"

--- a/userspace/nexus-ipc/src/host.rs
+++ b/userspace/nexus-ipc/src/host.rs
@@ -1,0 +1,134 @@
+// Copyright 2024 Open Nexus OS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-process IPC emulation for host-based tests.
+
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, TryRecvError};
+
+use parking_lot::Mutex;
+
+use crate::{Client, IpcError, Result, Server, Wait};
+
+/// Creates a loopback client/server pair backed by in-memory channels.
+pub fn loopback_channel() -> (LoopbackClient, LoopbackServer) {
+    let (req_tx, req_rx) = mpsc::channel::<Vec<u8>>();
+    let (rsp_tx, rsp_rx) = mpsc::channel::<Vec<u8>>();
+    (
+        LoopbackClient::new(req_tx, Mutex::new(rsp_rx)),
+        LoopbackServer::new(Mutex::new(req_rx), rsp_tx),
+    )
+}
+
+/// Client implementation backed by in-memory channels.
+pub struct LoopbackClient {
+    request_tx: Sender<Vec<u8>>,
+    response_rx: Mutex<Receiver<Vec<u8>>>,
+}
+
+impl LoopbackClient {
+    fn new(request_tx: Sender<Vec<u8>>, response_rx: Mutex<Receiver<Vec<u8>>>) -> Self {
+        Self {
+            request_tx,
+            response_rx,
+        }
+    }
+}
+
+impl Client for LoopbackClient {
+    fn send(&self, frame: &[u8], _wait: Wait) -> Result<()> {
+        self.request_tx
+            .send(frame.to_vec())
+            .map_err(|_| IpcError::Disconnected)
+    }
+
+    fn recv(&self, wait: Wait) -> Result<Vec<u8>> {
+        let receiver = self.response_rx.lock();
+        match wait {
+            Wait::Blocking => receiver.recv().map_err(|_| IpcError::Disconnected),
+            Wait::NonBlocking => receiver.try_recv().map_err(|err| match err {
+                TryRecvError::Empty => IpcError::WouldBlock,
+                TryRecvError::Disconnected => IpcError::Disconnected,
+            }),
+            Wait::Timeout(timeout) => {
+                if timeout.is_zero() {
+                    return receiver.try_recv().map_err(|err| match err {
+                        TryRecvError::Empty => IpcError::WouldBlock,
+                        TryRecvError::Disconnected => IpcError::Disconnected,
+                    });
+                }
+                receiver.recv_timeout(timeout).map_err(|err| match err {
+                    RecvTimeoutError::Timeout => IpcError::Timeout,
+                    RecvTimeoutError::Disconnected => IpcError::Disconnected,
+                })
+            }
+        }
+    }
+}
+
+/// Server implementation backed by in-memory channels.
+pub struct LoopbackServer {
+    request_rx: Mutex<Receiver<Vec<u8>>>,
+    response_tx: Sender<Vec<u8>>,
+}
+
+impl LoopbackServer {
+    fn new(request_rx: Mutex<Receiver<Vec<u8>>>, response_tx: Sender<Vec<u8>>) -> Self {
+        Self {
+            request_rx,
+            response_tx,
+        }
+    }
+}
+
+impl Server for LoopbackServer {
+    fn recv(&self, wait: Wait) -> Result<Vec<u8>> {
+        let receiver = self.request_rx.lock();
+        match wait {
+            Wait::Blocking => receiver.recv().map_err(|_| IpcError::Disconnected),
+            Wait::NonBlocking => receiver.try_recv().map_err(|err| match err {
+                TryRecvError::Empty => IpcError::WouldBlock,
+                TryRecvError::Disconnected => IpcError::Disconnected,
+            }),
+            Wait::Timeout(timeout) => {
+                if timeout.is_zero() {
+                    return receiver.try_recv().map_err(|err| match err {
+                        TryRecvError::Empty => IpcError::WouldBlock,
+                        TryRecvError::Disconnected => IpcError::Disconnected,
+                    });
+                }
+                receiver.recv_timeout(timeout).map_err(|err| match err {
+                    RecvTimeoutError::Timeout => IpcError::Timeout,
+                    RecvTimeoutError::Disconnected => IpcError::Disconnected,
+                })
+            }
+        }
+    }
+
+    fn send(&self, frame: &[u8], _wait: Wait) -> Result<()> {
+        self.response_tx
+            .send(frame.to_vec())
+            .map_err(|_| IpcError::Disconnected)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn loopback_roundtrip() {
+        let (client, server) = loopback_channel();
+        server.send(b"pong", Wait::Blocking).unwrap();
+        assert_eq!(client.recv(Wait::Blocking).unwrap(), b"pong");
+    }
+
+    #[test]
+    fn recv_timeout() {
+        let (client, _server) = loopback_channel();
+        let err = client
+            .recv(Wait::Timeout(Duration::from_millis(10)))
+            .unwrap_err();
+        assert_eq!(err, IpcError::Timeout);
+    }
+}

--- a/userspace/nexus-ipc/src/lib.rs
+++ b/userspace/nexus-ipc/src/lib.rs
@@ -1,0 +1,100 @@
+// Copyright 2024 Open Nexus OS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Minimal IPC runtime abstractions shared by host tests and the OS build.
+//!
+//! The host backend uses in-process channels to emulate kernel IPC and allows
+//! unit tests to execute Cap'n Proto request/response cycles without booting
+//! the full system. The OS backend delegates to the [`nexus-abi`] syscall
+//! wrappers and will be wired to the kernel in subsequent commits.
+
+#![forbid(unsafe_code)]
+#![deny(clippy::all, missing_docs)]
+#![allow(unexpected_cfgs)]
+
+use core::time::Duration;
+
+use thiserror::Error;
+
+/// Result type returned by IPC operations.
+pub type Result<T> = core::result::Result<T, IpcError>;
+
+/// Behaviour of a blocking call.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Wait {
+    /// Block until the operation completes.
+    Blocking,
+    /// Return immediately if no progress can be made.
+    NonBlocking,
+    /// Block until either the operation completes or the timeout expires.
+    Timeout(Duration),
+}
+
+impl Wait {
+    /// Returns `true` when the caller requested a non-blocking attempt.
+    pub const fn is_non_blocking(self) -> bool {
+        matches!(self, Self::NonBlocking)
+    }
+
+    /// Converts a [`Wait::Timeout`] variant into its [`Duration`].
+    pub const fn timeout(self) -> Option<Duration> {
+        match self {
+            Self::Timeout(duration) => Some(duration),
+            Self::Blocking | Self::NonBlocking => None,
+        }
+    }
+}
+
+/// Errors produced by the IPC runtime.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub enum IpcError {
+    /// Operation could not progress without blocking.
+    #[error("operation would block")]
+    WouldBlock,
+    /// The caller exceeded the requested timeout.
+    #[error("operation timed out")]
+    Timeout,
+    /// The opposite endpoint disconnected.
+    #[error("peer disconnected")]
+    Disconnected,
+    /// Kernel returned an IPC failure.
+    #[error("kernel rejected ipc request: {0:?}")]
+    Kernel(nexus_abi::IpcError),
+    /// IPC is not available under the current build.
+    #[error("ipc not supported for this configuration")]
+    Unsupported,
+}
+
+impl From<nexus_abi::IpcError> for IpcError {
+    fn from(err: nexus_abi::IpcError) -> Self {
+        Self::Kernel(err)
+    }
+}
+
+/// Client side of an IPC channel sending requests and receiving replies.
+pub trait Client {
+    /// Sends a request frame to the server.
+    fn send(&self, frame: &[u8], wait: Wait) -> Result<()>;
+
+    /// Receives a response frame from the server.
+    fn recv(&self, wait: Wait) -> Result<Vec<u8>>;
+}
+
+/// Server side of an IPC channel receiving requests and delivering replies.
+pub trait Server {
+    /// Receives the next request frame.
+    fn recv(&self, wait: Wait) -> Result<Vec<u8>>;
+
+    /// Sends a response frame back to the caller.
+    fn send(&self, frame: &[u8], wait: Wait) -> Result<()>;
+}
+
+#[cfg(nexus_env = "host")]
+mod host;
+#[cfg(nexus_env = "host")]
+pub use host::{loopback_channel, LoopbackClient, LoopbackServer};
+
+#[cfg(nexus_env = "os")]
+mod os;
+#[cfg(nexus_env = "os")]
+pub use os::{KernelClient, KernelServer};

--- a/userspace/nexus-ipc/src/os.rs
+++ b/userspace/nexus-ipc/src/os.rs
@@ -1,0 +1,51 @@
+// Copyright 2024 Open Nexus OS Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Kernel-backed IPC implementation.
+
+use crate::{Client, IpcError, Result, Server, Wait};
+
+/// Client backed by kernel IPC. The implementation is provided once the kernel
+/// syscall layer is ready; for now all operations return [`IpcError::Unsupported`].
+pub struct KernelClient;
+
+impl KernelClient {
+    /// Attempts to create a new kernel IPC client bound to the process' default
+    /// channel. The kernel backend is not wired yet, therefore the function
+    /// currently returns [`Err(IpcError::Unsupported)`].
+    pub const fn new() -> Result<Self> {
+        Err(IpcError::Unsupported)
+    }
+}
+
+impl Client for KernelClient {
+    fn send(&self, _frame: &[u8], _wait: Wait) -> Result<()> {
+        Err(IpcError::Unsupported)
+    }
+
+    fn recv(&self, _wait: Wait) -> Result<Vec<u8>> {
+        Err(IpcError::Unsupported)
+    }
+}
+
+/// Server backed by kernel IPC.
+pub struct KernelServer;
+
+impl KernelServer {
+    /// Attempts to create a new kernel IPC server bound to the process' default
+    /// channel. The syscall wiring is still pending and this function returns
+    /// [`Err(IpcError::Unsupported)`] until the kernel integration lands.
+    pub const fn new() -> Result<Self> {
+        Err(IpcError::Unsupported)
+    }
+}
+
+impl Server for KernelServer {
+    fn recv(&self, _wait: Wait) -> Result<Vec<u8>> {
+        Err(IpcError::Unsupported)
+    }
+
+    fn send(&self, _frame: &[u8], _wait: Wait) -> Result<()> {
+        Err(IpcError::Unsupported)
+    }
+}


### PR DESCRIPTION
## Summary
- stub kernel-backed nexus-ipc backend returning Unsupported and add host helpers for loopback testing
- implement nexus-init binary to load service recipes, launch samgrd/bundlemgrd, and emit readiness markers
- wire samgrd and bundlemgrd to the new nexus-ipc transport with host loopback helpers and readiness notifiers

## Testing
- cargo test -p nexus-ipc
- cargo test -p nexus-init

------
https://chatgpt.com/codex/tasks/task_e_68e59023431c8327a28649d1c210f63b